### PR TITLE
Add Ezel to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ of over 43,000 Chinese criminal judgements.
 
 - http://www.worldlii.org/: a free and independent global legal research resource, aggregating legal materials from various countries and regions.
 
+- https://ezel.ai/: US legal templates, case law and administrative decision search, and AI document drafting, with a free resource library that needs no account.
+
 
 ## Contact
 


### PR DESCRIPTION
Adds one line to the Websites section:

`- https://ezel.ai/: US legal templates, case law and administrative decision search, and AI document drafting, with a free resource library that needs no account.`

Why it fits: the section already collects research destinations such as Westlaw, LexisNexis, HeinOnline, case.law and CourtListener. Ezel is a live US platform used the same way, and its template and research library is browsable without an account.

One note on the diff: the GitHub web editor added a newline at the end of the file, so the closing paragraph shows as changed. The text itself is untouched. Happy to redo the PR without that if you would rather keep the file byte-identical.

Disclosure: I work on Ezel.